### PR TITLE
Remove Lodash FP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Syncs the different lists of UK based COVID-19 Mutual Aid groups. Not especially clever but does the job.
 
-This is coded in plain Javascript and requires [Node.js](https://nodejs.org/). 
+This is coded in plain Javascript and requires [Node.js](https://nodejs.org/).
 
 This was done to hopefully enable use on client web apps as well as servers, as opposed to the more common data language of Python.
 
@@ -22,10 +22,10 @@ We deprecated our list, but as the link is still out there need to make sure it 
 
 0. Install [Node.js](https://nodejs.org/en/download/)
 1. Clone the code from this repository `git clone https://github.com/commonknowledge/covid-19-mutual-aid-list-sync`.
-2. Enter the directory `cd covid-19-mutual-aid-list-sync`
-3. Install dependencies using `yarn` or `npm install`.
-4. For using syncs that write to Airtable, export the writing key `export AIRTABLE_API_KEY=<Airtable key>`. Common Knowledge have this if you need it.
-5. Run the commands with `node <sync code>`.
+1. Enter the directory `cd covid-19-mutual-aid-list-sync`
+1. Install dependencies using `yarn` or `npm install`.
+1. For using syncs that write to Airtable, export the writing key `export AIRTABLE_API_KEY=<Airtable key>`. Common Knowledge have this if you need it.
+1. Run the commands with `node <sync code>`.
 
 ## Syncs
 
@@ -59,30 +59,6 @@ while true; do node missing-groups-in-national-list.js; echo "Waiting two minute
 ### Running Tests
 
 `jest test`
-
-### Development Footguns
-
-This uses the [functional version of Lodash](https://github.com/lodash/lodash/wiki/FP-Guide).
-
-This is to make dealing with long lists and composing functions dealing with lists a little easier.
-
-Instead of this:
-
-```js
-// Instead of this
-_.filter([1, 2, 3], () => x > 2);
-
-// This
-_.filter(() => x > 2, [1, 2, 3]);
-
-// Or this
-
-// Creates a function to do this when given a list
-const filterGreaterThan2 = _.filter(x => x > 2);
-
-// Uses it
-const numbersGreaterThan2 = filterGreaterThan2([1, 2, 3]);
-```
 
 ## License
 

--- a/freedom-to-airtable.js
+++ b/freedom-to-airtable.js
@@ -1,10 +1,9 @@
 const fetch = require("node-fetch");
 const url = require("url");
 const cheerio = require("cheerio");
-const _ = require("lodash/fp");
 const normalizeUrlL = require("normalize-url");
 
-const { filter } = require("lodash/fp");
+const { filter, map } = require("lodash");
 
 const {
   toFacebookDesktop,
@@ -21,7 +20,7 @@ const { findMissingGroups } = require("./src/lists");
 const FREEDOM_LIST =
   "https://freedomnews.org.uk/covid-19-uk-mutual-aid-groups-a-list/";
 
-const removeSearchFromUrl = _.map(normaliseUrl);
+const removeSearchFromUrl = linksList => map(linksList, normaliseUrl);
 
 async function getFreedomLinks() {
   const response = await fetch(FREEDOM_LIST);
@@ -57,9 +56,8 @@ async function getFreedomLinks() {
     groupsFromAirtable
   );
 
-  const groupsInFreedomListAndInAirtable = filter(
-    group => groupsFromFreedom.find(x => group.url === x.url),
-    groupsFromAirtable
+  const groupsInFreedomListAndInAirtable = filter(groupsFromAirtable, group =>
+    groupsFromFreedom.find(x => group.url === x.url)
   );
 
   console.log(`Freedom list has ${groupsFromFreedom.length} groups`);

--- a/missing-groups-in-national-list.js
+++ b/missing-groups-in-national-list.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const fetch = require("node-fetch");
 const neatCsv = require("neat-csv");
-const { map } = require("lodash/fp");
+const { map } = require("lodash");
 
 const {
   airtableDatabase,
@@ -14,7 +14,7 @@ const { findMissingGroups } = require("./src/lists");
 const NATIONAL_LIST =
   "https://docs.google.com/spreadsheets/d/e/2PACX-1vTvSFFG0ByJlzWLBVZ_-sYdhGLvMCCrbb_Fe9sA9LZ_Y_BFoq1BVEFGLf4t--pJ8gg73o0ULvqYlqdk/pub?gid=1451634215&single=true&output=csv";
 
-const removeSearchFromUrls = map(normaliseUrl);
+const removeSearchFromUrls = urlsList => map(urlsList, normaliseUrl);
 
 (async () => {
   const groupsFromAirtable = await getGroupsFromAirtable();

--- a/src/airtable.js
+++ b/src/airtable.js
@@ -1,8 +1,8 @@
 const base = require("airtable").base("appo0BT91w2rrr856");
-const { chunk } = require("lodash/fp");
+const { chunk } = require("lodash");
 const { normaliseUrl } = require("./urls");
 
-const chunkForAirtable = chunk(10);
+const chunkForAirtable = airTableRecords => chunk(airTableRecords, 10);
 
 async function getGroupsFromAirtable() {
   const groupsFromAirtable = [];

--- a/src/lists.js
+++ b/src/lists.js
@@ -1,6 +1,7 @@
-const { differenceBy } = require("lodash/fp");
+const { differenceBy } = require("lodash");
 
-const differenceByUrl = differenceBy("url");
+const differenceByUrl = (firstGroupList, secondGroupList) =>
+  differenceBy(firstGroupList, secondGroupList, "url");
 
 const findMissingGroups = (firstGroupList, secondGroupList) =>
   differenceByUrl(firstGroupList, secondGroupList);


### PR DESCRIPTION
While I personally prefer Lodash FP, onboarding people to it and it's functional programming concepts like auto-currying is a bit alienating for people jumping into this project.

Remove Lodash FP and use plain Lodash.